### PR TITLE
add external file to payload manifests

### DIFF
--- a/example1/fetch.txt
+++ b/example1/fetch.txt
@@ -1,1 +1,1 @@
-https://gist.githubusercontent.com/anonymous/7fe620279ea4988a5a1e/raw/e55d9ea6af35ea67cfaf47b03a2b71f9026325fd/external.txt 99 /data/external.txt
+https://gist.githubusercontent.com/anonymous/7fe620279ea4988a5a1e/raw/e55d9ea6af35ea67cfaf47b03a2b71f9026325fd/external.txt 99 data/external.txt

--- a/example1/manifest-md5.txt
+++ b/example1/manifest-md5.txt
@@ -1,4 +1,5 @@
 65316af1aad9b64b3e53dca4f2e05171  data/README.md
 5ebeffbb71b601953be62f49d78a7f01  data/analyse.py
+ab3ddecccc42407bf93b032c7421d8ab  data/external.txt
 32bf1a6cde292d7df1aab03fadd6d681  data/numbers.csv
 b1d5533bdf834910d590baee297f962a  data/results.txt

--- a/example1/manifest-sha1.txt
+++ b/example1/manifest-sha1.txt
@@ -1,4 +1,5 @@
 772d5a86fe66d431b1299a0d733787b0ad5d2538  data/README.md
 aaf0b3590bfbda2d51fc9af832226fc8cfbf7e90  data/analyse.py
+ddf9aefab8abf92ff28a3bb80d2d0cd528bf8d7c  data/external.txt
 6e99ddf659e21ea9052e8f5e4c6d98fe5097b22b  data/numbers.csv
 a16b003d6cbdc971e4b8b59e9d3893d8a128b8e1  data/results.txt


### PR DESCRIPTION
The external file in the example fetch.txt file is not present in the payload manifest files. This was always a requirement of the 0.97 BagIt spec, and is more explicit in the 1.0 version: "Every file listed in the fetch file MUST be listed in every payload manifest" (https://tools.ietf.org/html/draft-kunze-bagit-17#section-2.2.3)